### PR TITLE
Use config package from v2ray.com/ext

### DIFF
--- a/configureFileutli.go
+++ b/configureFileutli.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	v2rayJsonWithComment "v2ray.com/core/tools/conf/json"
+	v2rayJsonWithComment "v2ray.com/ext/encoding/json"
 )
 
 type cfgtmpvars struct {

--- a/interact.go
+++ b/interact.go
@@ -10,8 +10,7 @@ import (
 	"v2ray.com/core/app/log"
 	"v2ray.com/core/common/errors"
 
-	// For json config parser
-	_ "v2ray.com/core/tools/conf"
+	v2rayconf "v2ray.com/ext/tools/conf/serial"
 )
 
 /*V2RayPoint V2Ray Point Server
@@ -66,7 +65,7 @@ func (v *V2RayPoint) pointloop() {
 	log.Trace(errors.New("v.renderAll()"))
 	v.renderAll()
 
-	config, err := core.LoadConfig(core.ConfigFormat_JSON, v.parseCfg())
+	config, err := v2rayconf.LoadJSONConfig(v.parseCfg())
 	if err != nil {
 		log.Trace(errors.New("Failed to read config file (", v.ConfigureFile, "): ", v.ConfigureFile).Base(err).AtError())
 


### PR DESCRIPTION
The plan is to move conf package out of core. V2Ray Core will eventually take config in protobuf format only. The conf package will run as a separate binary. This PR is to remove references to core/tools/conf, so that further refactoring can be done.